### PR TITLE
Fix create_chart closure and reconstruct UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,14 @@ Para executar o aplicativo localmente:
 ```r
 shiny::runApp()
 ```
+
+## Executando com Docker
+
+Para construir e iniciar o contêiner localmente:
+
+```bash
+docker build -t painel_caged_portuario .
+docker run -p 3838:3838 painel_caged_portuario
+```
+
+A aplicação estará disponível em <http://localhost:3838>.

--- a/app.R
+++ b/app.R
@@ -103,15 +103,17 @@ create_chart <- function(mes) {
       )
     ) %>%
     hc_yAxis(title = list(text = "")) %>%
-    hc_add_series(name = "", data = dados$saldo_somado) %>%
+    hc_add_series(name = "", data = dados$saldo_somado)
+}
+
+ui <- dashboardPage(
+  dashboardHeader(
     title = tags$div(
-      tags$strong("Mercado de Trabalho Portuário", 
-                  class = "title-text"),  # Aumenta o tamanho e deixa em negrito
+      tags$strong("Mercado de Trabalho Portuário", class = "title-text"),
       style = "text-align: center; padding-right: 20px;"
     ),
-    titleWidth = NULL  # Permite que a largura seja ajustada dinamicamente
+    titleWidth = NULL
   ),
-  
   dashboardSidebar(
     tags$div(
       tags$img(src = "img/logo.png", height = "50px", width = "200px"),  
@@ -190,9 +192,9 @@ Para uma melhor experiência, abra o painel no seu computador.",
                            status = "primary")
                 ),
                 column(5, 
-                       box(title = "Mapa do saldo de empregos", width = NULL, highchartOutput("mapa"), 
+                       box(title = "Mapa do saldo de empregos", width = NULL, highchartOutput("mapa"),
                            solidHeader = TRUE,
-                           status = "primary",)
+                           status = "primary")
                 )
               ),
               # Novo fluidRow para os gráficos de sexo lado a lado


### PR DESCRIPTION
## Summary
- close `create_chart` after finishing the highchart pipeline
- rebuild dashboard page into `ui` with `dashboardHeader`, `dashboardSidebar` and `dashboardBody`
- use the new `ui` object when launching `shinyApp`
- document how to build and run the app with Docker

## Testing
- `docker --version`
- `docker build -t painel_caged_portuario .` *(fails: daemon not running)*
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406aeab3948324a74adf22b358f94b